### PR TITLE
Update setup.ps1

### DIFF
--- a/scripts/final/setup.ps1
+++ b/scripts/final/setup.ps1
@@ -1,5 +1,5 @@
 $envFile = ".env";
-$configFile = ".config";
+$configFile = "config.json";
 # TODO: create function
 if (-not [System.IO.File]::Exists($envFile))
 {


### PR DESCRIPTION
It was looking for ".config.example" file, however only "config.json.example" was present. At first I just changed the file name in the source files, but then error was popping up that Deno.exe could not find "config.json.example". Therefore the easiest solution was to change the constant in the script